### PR TITLE
Précision pour  Error: Expecting LINESTRING geometry for 'road'

### DIFF
--- a/R/mffp_road.R
+++ b/R/mffp_road.R
@@ -81,9 +81,10 @@ measure_road = function(ctg, road, dtm, water = NULL, param = mffproads_default_
 {
   dots <- list(...)
   lidR::opt_progress(ctg) <- FALSE
-  if (sf::st_geometry_type(road) != "LINESTRING") stop("Expecting LINESTRING geometry for 'road'", call. = FALSE)
+  geometry_type_road <- sf::st_geometry_type(road)
+  if (geometry_type_road != "LINESTRING") stop(glue::glue("Expecting LINESTRING geometry for 'road' but {geometry_type_road} found instead."), call. = FALSE)
   if (nrow(road) > 1) stop("Expecting a single LINESTRING", call. = FALSE)
-  if (!methods::is(ctg, "LAScatalog")) stop("Expecting a LAscatalog", call. = FALSE)
+  if (!methods::is(ctg, "LAScatalog")) stop("Expecting a LAScatalog", call. = FALSE)
   if (!is.null(water)) { if (any(!sf::st_geometry_type(water) %in% c("MULTIPOLYGON", "POLYGON"))) stop("Expecting POLYGON geometry type for 'water'", call. = FALSE) }
   if (!isFALSE(dots$Windex)) { if (!lidR::is.indexed(ctg)) message("No spatial index for LAS/LAZ files in this collection.") }
   if (getOption("MFFProads.debug.progress")) cat("Progress: ")


### PR DESCRIPTION
Lorsque le type de géométrie de la couche de chemins soumise n'est pas `LINESTRING` son type est maintenant retourné. Je précise car parfois on est certain que notre couche est belle et bien constituée de lignes... mais on ne pense pas à la différence `LINESTRING`/`MULTILINESTRING`.

```
# Avant
Error: Expecting LINESTRING geometry for 'road'

# Maintenant
Error: Expecting LINESTRING geometry for 'road' but MULTILINESTRING found instead.
```