### PR TITLE
Méthode alternative de retrait des vertex tombant dans les caps

### DIFF
--- a/R/lcp_tools.R
+++ b/R/lcp_tools.R
@@ -181,10 +181,9 @@ transition <- function(conductivity)
 
 find_path = function(conductivity, centerline, A, B, param)
 {
-  caps <- make_caps(centerline, param)$caps
-
   # Caps rasterisation
   caps_raster <- conductivity
+  caps <- make_caps(centerline, param)
   xy <- raster::xyFromCell(caps_raster, 1: raster::ncell(caps_raster))
   xy <- as.data.frame(xy)
   xy$z <- 0

--- a/R/lcp_tools.R
+++ b/R/lcp_tools.R
@@ -81,9 +81,12 @@ least_cost_path = function(las, centerline, dtm, conductivity, water, param)
   A  <- AB$A
   B  <- AB$B
 
+  # Compute the transition
+  trans <- transition(conductivity)
+
   # Find the path
   verbose("Computing least cost path...\n")
-  path <- find_path(conductivity, centerline, A, B, param)
+  path <- find_path(trans, centerline, A, B, param)
 
   return(path)
 }
@@ -179,11 +182,11 @@ transition <- function(conductivity)
   return(trans)
 }
 
-find_path = function(conductivity, centerline, A, B, param)
+find_path = function(trans, centerline, A, B, param)
 {
   # Caps rasterisation
-  caps_raster <- conductivity
   caps <- make_caps(centerline, param)
+  caps_raster <- raster::raster(trans)
   xy <- raster::xyFromCell(caps_raster, 1: raster::ncell(caps_raster))
   xy <- as.data.frame(xy)
   xy$z <- 0
@@ -196,7 +199,7 @@ find_path = function(conductivity, centerline, A, B, param)
   res <- !is.na(lidR:::point_in_polygons(xy, caps$shields))
   caps_raster[res] <- 0
 
-  trans <- transition(conductivity)
+  
   trans@crs <- methods::as(sf::NA_crs_, "CRS") # workaround to get rid of rgdal warning
 
   cost <- gdistance::costDistance(trans, A, B)

--- a/R/lcp_tools.R
+++ b/R/lcp_tools.R
@@ -216,7 +216,7 @@ find_path = function(conductivity, centerline, A, B, param)
   len  <- sf::st_length(path)
 
   # Trim vertex inside caps
-  coords <- st_coordinates(path)[,1:2]
+  coords <- sf::st_coordinates(path)[,1:2]
   val <- raster::extract(caps_raster, coords)
   path <- sf::st_linestring(coords[val != 1,])
 

--- a/R/road_tools.R
+++ b/R/road_tools.R
@@ -14,8 +14,8 @@ road_measure = function(las, road, param)
   end <- coords_road[nrow(coords_road),1:2]
 
   # Split the path in n sections of ~ same length
-  path_lenght <- as.numeric(sf::st_length(road))
-  each <- param[["extraction"]][["section_length"]]/path_lenght
+  path_length <- as.numeric(sf::st_length(road))
+  each <- param[["extraction"]][["section_length"]]/path_length
   at <- round(seq(0,1, each),4)
   at[length(at)] = 1
   points <- sf::st_line_sample(road, sample = at)
@@ -31,7 +31,7 @@ road_measure = function(las, road, param)
   dd  <- sqrt(dx*dx+dy*dy)
   dist <- cumsum(dd[-length(dd)])
   pdist <- dist/dist[length(dist)]
-  points$DISTANCE <- path_lenght*pdist
+  points$DISTANCE <- path_length*pdist
 
   # We can now loop through each segment between two consecutive points
   n <- nrow(CC)


### PR DESCRIPTION
Corrige #42.

Au lieu d'utiliser `sf::st_difference(path, caps)`, je regarde quels sommets de `path` tombent dans les caps (valeur de conductivité de 1) et je les retire. C'est probablement moins performant que `sf::st_difference()`, mais pas suffisamment pour percevoir la différence.