### PR TITLE
`find_best_connexion()` plus exact

### DIFF
--- a/R/line_tools.R
+++ b/R/line_tools.R
@@ -18,9 +18,9 @@ st_ends_heading <- function(line)
     Ay = M[i-j,2]
     Bx = M[i,1]
     By = M[i,2]
-    unname(atan2(Ay-By, Ax-Bx))*180/pi
+    atan2(Ay-By, Ax-Bx)*180/pi
   })
-  
+  names(headings) <- c("head", "tail")
   return(headings)
 }
 

--- a/R/snap_tools.R
+++ b/R/snap_tools.R
@@ -489,24 +489,24 @@ find_best_connexion <- function(tb_node)
     if (a < 0) a <- 360 + a
     min(a, 360 - a)
   }
-  comb_heading <- apply(m_row, 2, function(x) min_diff_angle(tb_node[["heading"]][x[1]], tb_node[["heading"]][x[2]]))
+  comb_angle <- apply(m_row, 2, function(x) min_diff_angle(tb_node[["heading"]][x[1]], tb_node[["heading"]][x[2]]))
 
   # Give a chance to lines that have an angle close to "flattest" one to
   # be considered "as flat". The flatness of the angle being the the prime
   # driver of the selection, we want to avoid a CLASS 0 line taking
   # precedence over a CLASS 1 line for a mere 5° difference
   tolerance_angle <- 7.5  # Allow angle up to 7.5° more
-  idx_min <- which.min(comb_heading)[1]
-  comb_heading[comb_heading <= comb_heading[idx_min] + tolerance_angle] <- 0
+  idx_max <- which.max(comb_angle)[1]
+  comb_angle[comb_angle >= comb_angle[idx_max] - tolerance_angle] <- 180
 
   # Build similarity table using all permutations
   tb_similarity <-
     dplyr::tibble(
       pairs        = 1:ncol(m_row),
-      comb_heading = comb_heading,
+      comb_angle   = comb_angle,
       comb_class   = apply(m_row, 2, function(x) sum(tb_node[["CLASS"]][x]) ),
       comb_score   = apply(m_row, 2, function(x) sum(tb_node[["SCORE"]][x], na.rm = TRUE) )) |>
-    dplyr::arrange(comb_heading, comb_class, dplyr::desc(comb_score))
+    dplyr::arrange(dplyr::desc(comb_angle), comb_class, dplyr::desc(comb_score))
 
   # The best fit is based on (in order):
   #  - the angle formed between the segments (the flatter the better)

--- a/R/snap_tools.R
+++ b/R/snap_tools.R
@@ -474,38 +474,39 @@ distance_line_intersection <- function(crossing_line, reference_line, reference_
 #' @noRd
 find_best_connexion <- function(tb_node)
 {
-  # Compute distance matrix between the end of each unitary vector formed by
-  # the (reverse) heading of each line. The idea is that if two lines are 180°
-  # apart, the distance between the two ends will be 2 but if they are only
-  # 60° apart, the distance will be 1. It curves the issue of adding and subtracting
-  # angle values constrained in a [-pi, pi] / [-180, 180] range.
-  mat_dist <- data.frame(X = cos((tb_node[["heading"]] + 180) * pi / 180),
-                         Y = sin((tb_node[["heading"]] + 180) * pi / 180)) |>
-    stats::dist() |>
-    as.matrix()
-  idx_max <- which.max(mat_dist)
+  # Update CLASS 0 to CLASS 5 in order to get a constant
+  # quality gradient from 1 to 5 for an easier sort
+  tb_node <- dplyr::mutate(tb_node, CLASS = ifelse(CLASS == 0, 5, CLASS))
+
+  # Produce lines permutations (as row number)
+  m_row <- utils::combn(1:nrow(tb_node), 2)
+
+  # Compute minimal angle difference between each lines
+  min_diff_angle <- function(x, y)
+  {
+    a <- x - y
+    if (a > 180) a <- 360 - a
+    if (a < 0) a <- 360 + a
+    min(a, 360 - a)
+  }
+  comb_heading <- apply(m_row, 2, function(x) min_diff_angle(tb_node[["heading"]][x[1]], tb_node[["heading"]][x[2]]))
 
   # Give a chance to lines that have an angle close to "flattest" one to
   # be considered "as flat". The flatness of the angle being the the prime
   # driver of the selection, we want to avoid a CLASS 0 line taking
   # precedence over a CLASS 1 line for a mere 5° difference
-  max_angle <- 7.5 * (pi / 180)  # Angle down to 7.5° less allowed
-  dist_angle <- sqrt((cos(max_angle) - 1)^2 + sin(max_angle)^2)
-  mat_dist[ mat_dist >= (mat_dist[idx_max] - dist_angle) ] <- 2
-
-  # Update CLASS 0 to CLASS 5 in order to get a constant
-  # quality gradient from 1 to 5 for an easier sort
-  tb_node <- dplyr::mutate(tb_node, CLASS = ifelse(CLASS == 0, 5, CLASS))
+  tolerance_angle <- 7.5  # Allow angle up to 7.5° more
+  idx_min <- which.min(comb_heading)[1]
+  comb_heading[comb_heading <= comb_heading[idx_min] + tolerance_angle] <- 0
 
   # Build similarity table using all permutations
-  m_row   <- utils::combn(1:nrow(tb_node), 2)
   tb_similarity <-
     dplyr::tibble(
       pairs        = 1:ncol(m_row),
-      comb_heading = apply(m_row, 2, function(x) mat_dist[x[1], x[2]] ),
+      comb_heading = comb_heading,
       comb_class   = apply(m_row, 2, function(x) sum(tb_node[["CLASS"]][x]) ),
       comb_score   = apply(m_row, 2, function(x) sum(tb_node[["SCORE"]][x], na.rm = TRUE) )) |>
-    dplyr::arrange(dplyr::desc(comb_heading), comb_class, dplyr::desc(comb_score))
+    dplyr::arrange(comb_heading, comb_class, dplyr::desc(comb_score))
 
   # The best fit is based on (in order):
   #  - the angle formed between the segments (the flatter the better)


### PR DESCRIPTION
Règle générale, la fonction fonctionnait bien, mais il y avait une faille dans la façon dont je calculais la différence d'angle entre les segments qui faisait en sorte que, parfois, la solution optimale (ayant un angle le plus plat possible, soit le plus près de 180°) n'était pas choisie. Je me suis certainement compliqué la vie avec ma nouvelle méthode, mais au moins là ça fonctionne. Ça pourra toujours être revisité.

```r
ori1 <- st_sfc(sf::st_linestring(matrix(c(-259453.9, 377891.1, -259426.9, 377864.3), ncol=2, byrow=T)))
ori2 <- st_sfc(sf::st_linestring(matrix(c(-259453.9, 377891.1, -259419.3, 377881.5), ncol=2, byrow=T)))
ori3 <- st_sfc(sf::st_linestring(matrix(c(-259453.9, 377891.1, -259460.4, 377921.9), ncol=2, byrow=T)))
ori <- st_sf(c(ori1, ori2, ori3), crs = st_crs("EPSG:6622"), id = LETTERS[1:3], SCORE = c(85,50,90), CLASS = c(1,2,1))
ori["heading"] <- sapply(st_geometry(ori), function(x) ALSroads:::st_ends_heading(x)[1])
ori["norm_heading"] <- ifelse(ori[["heading"]] < 0, ori[["heading"]] + 180, ori[["heading"]])
plot(ori["id"])
```

![image](https://user-images.githubusercontent.com/32580398/158465351-fe2c9e45-07ec-45f2-b88e-62f78a6305d4.png)

```r
# Résultat avec code actuel:
ALSroads:::find_best_connexion(ori)
# [1] "A" "B"

# Résultat avec cette PR:
ALSroads:::find_best_connexion(ori)
# [1] "A" "C"
```


À noter que j'ai aussi apporté des modifications dans check_postprod.R qui affectent seulement l'ordre et le nom de certaines variables pour être plus cohérent avec le restant du code.