### PR TITLE
Ajouts d'avertissements pour cas spéciaux dans `advanced_snap`

### DIFF
--- a/R/line_tools.R
+++ b/R/line_tools.R
@@ -127,13 +127,17 @@ st_split_at_point <- function(split_point, line, tolerance = 0.01)
   if (as.numeric(sf::st_length(blade)) > tolerance) stop("'split_point' too far from 'line' to perform split")
 
   # Sharpen blade (by slightly extending it)!
+  # Not ideal as this blade extention could cause the line
+  # to be splitted at more than one place. I can also reach
+  # the precision limit of Float64 representation for the
+  # coordinates
   coords <- sf::st_coordinates(blade)
   theta <- atan2(diff(coords[,2]), diff(coords[,1]))
 
-  xmax <- max(coords[,"X"]) + abs(0.01 * cos(theta))
-  ymax <- max(coords[,"Y"]) + abs(0.01 * sin(theta))
-  xmin <- min(coords[,"X"]) - abs(0.01 * cos(theta))
-  ymin <- min(coords[,"Y"]) - abs(0.01 * sin(theta))
+  xmax <- max(coords[,"X"]) + abs(0.0001 * cos(theta))
+  ymax <- max(coords[,"Y"]) + abs(0.0001 * sin(theta))
+  xmin <- min(coords[,"X"]) - abs(0.0001 * cos(theta))
+  ymin <- min(coords[,"Y"]) - abs(0.0001 * sin(theta))
   
   # Split line and extract the two parts
   split_line <- rbind(c(xmax, ymax), c(xmin, ymin)) |>

--- a/R/snap_tools.R
+++ b/R/snap_tools.R
@@ -363,6 +363,19 @@ advanced_snap <- function(roads, ref, field, tolerance, updatable)
     # two segments composing it and get coordinates
     # of the final junction point
     bridge_geometries <- st_split_at_point(mean_junction, bridge[["bridge"]])
+
+    if (length(bridge_geometries) != 2)
+    {
+      pos <- tb_node[["pos"]]
+      IDs_node <- roads[pos,][[field]]
+      IDs_glued <- glue::glue_collapse(IDs_node, ", ")
+      
+      warning(glue::glue("Impossible to connect together roads with '{field}' {IDs_glued}; issue occured during a splitting operation."), call.=FALSE)
+      df_pts_warn <- data.frame(tb_node_ref[1, c("X","Y")], message = "Issue occured during a splitting operation", IDs = IDs_glued) |>
+        rbind(df_pts_warn)
+      next
+    }
+
     coords_junction <- sf::st_coordinates(bridge_geometries[2])[1,-3]
 
     # Reorder vertices in order to match the original

--- a/R/snap_tools.R
+++ b/R/snap_tools.R
@@ -201,6 +201,11 @@ advanced_snap <- function(roads, ref, field, tolerance, updatable)
     tb_node_ref <- dplyr::filter(tb_ends_ref, id %in% IDs)
     tb_node_cor <- dplyr::filter(tb_ends_roads, id %in% IDs)
 
+    # Prepare IDs string for potential warning message
+    pos <- unique(tb_node[["pos"]])
+    IDs_node <- roads[pos,][[field]]
+    IDs_glued <- glue::glue_collapse(IDs_node, ", ")
+
 
     # Will only try snapping if at least one of the segments
     # in the group has been corrected as they will already
@@ -224,10 +229,6 @@ advanced_snap <- function(roads, ref, field, tolerance, updatable)
     gap <- sqrt(diff(tb_node_bridge[["X"]])^2 + diff(tb_node_bridge[["Y"]])^2)
     if (gap/2 > tolerance)
     {
-      pos <- tb_node[["pos"]]
-      IDs_node <- roads[pos,][[field]]
-      IDs_glued <- glue::glue_collapse(IDs_node, ", ")
-
       warning(glue::glue("Impossible to connect together roads with '{field}' {IDs_glued}; distance from expected junction exceeds tolerance ({round(gap/2,1)} > {tolerance} {dist_unit})."), call.=FALSE)
       df_pts_warn <- data.frame(tb_node_ref[1, c("X","Y")], message = "Distance from expected junction exceeds tolerance", IDs = IDs_glued) |>
         rbind(df_pts_warn)
@@ -274,12 +275,8 @@ advanced_snap <- function(roads, ref, field, tolerance, updatable)
         # it justifies the complexity that would need to be added to the rest of the script
         # One way of doing it would be to split each loop before searching for the best
         # junction point and then only at the end recombining each loop.
-        pos <- as.numeric(names(tb_pos))
-        IDs_node <- roads[pos,][[field]]
-        IDs_glued <- glue::glue_collapse(IDs_node, ", ")
-        
         warning(glue::glue("Impossible to connect together roads with '{field}' {IDs_glued}; junction contains one loop and at least two other roads."), call.=FALSE)
-        df_pts_warn <- data.frame(tb_node_ref[1, c("X","Y")], message = "Junction contains one loop and at least 2 other roads", IDs = IDs_glued) |>
+        df_pts_warn <- data.frame(tb_node_ref[1, c("X","Y")], message = "Junction contains one loop and at least two other roads", IDs = IDs_glued) |>
           rbind(df_pts_warn)
       }
       next
@@ -326,10 +323,6 @@ advanced_snap <- function(roads, ref, field, tolerance, updatable)
 
     if (dist_max > tolerance)
     {
-      pos <- tb_node[["pos"]]
-      IDs_node <- roads[pos,][[field]]
-      IDs_glued <- glue::glue_collapse(IDs_node, ", ")
-
       warning(glue::glue("Impossible to connect together roads with '{field}' {IDs_glued}; distance from expected junction exceeds tolerance ({round(dist_max,1)} > {tolerance} {dist_unit})."), call.=FALSE)
       df_pts_warn <- data.frame(tb_node_ref[1, c("X","Y")], message = "Distance from expected junction exceeds tolerance", IDs = IDs_glued) |>
         rbind(df_pts_warn)
@@ -349,10 +342,6 @@ advanced_snap <- function(roads, ref, field, tolerance, updatable)
     # but already connected at one end of the bridge
     if (dist_junction_mean == 0)
     {
-      pos <- tb_node[["pos"]]
-      IDs_node <- roads[pos,][[field]]
-      IDs_glued <- glue::glue_collapse(IDs_node, ", ")
-      
       warning(glue::glue("Impossible to connect together roads with '{field}' {IDs_glued}; junction weirdly occurs at exactly one end of a road."), call.=FALSE)
       df_pts_warn <- data.frame(tb_node_ref[1, c("X","Y")], message = "Junction weirdly occurs at exactly one end of a road", IDs = IDs_glued) |>
         rbind(df_pts_warn)
@@ -366,10 +355,6 @@ advanced_snap <- function(roads, ref, field, tolerance, updatable)
 
     if (length(bridge_geometries) != 2)
     {
-      pos <- tb_node[["pos"]]
-      IDs_node <- roads[pos,][[field]]
-      IDs_glued <- glue::glue_collapse(IDs_node, ", ")
-      
       warning(glue::glue("Impossible to connect together roads with '{field}' {IDs_glued}; issue occured during a splitting operation."), call.=FALSE)
       df_pts_warn <- data.frame(tb_node_ref[1, c("X","Y")], message = "Issue occured during a splitting operation", IDs = IDs_glued) |>
         rbind(df_pts_warn)
@@ -431,11 +416,6 @@ advanced_snap <- function(roads, ref, field, tolerance, updatable)
       if (length(road_split) == 1)
       {
         ID_problem <- roads[pos,][[field]]
-        
-        pos <- tb_node[["pos"]]
-        IDs_node <- roads[pos,][[field]]
-        IDs_glued <- glue::glue_collapse(IDs_node, ", ")
-        
         warning(glue::glue("Impossible to connect road with '{field}' {ID_problem} inside node of {IDs_glued}; the road doesn't intersect other roads but weirdly is still very close."), call.=FALSE)
         df_pts_warn <- data.frame(tb_node_ref[1, c("X","Y")], message = "Road doesn't seem to intersect with others inside node", IDs = ID_problem) |>
           rbind(df_pts_warn)


### PR DESCRIPTION
Trois nouveaux cas spéciaux à traiter:

1. Lorsqu'une intersection avec le "pont" s'effectuait à l'une de ses extrémités. Avertissement nécessaire car pas normal, indique que l'un des chemins est vraiment mal repositionné.
2. Les cas où une loop était présente dans une intersection n'était pas bien géré. Maintenant c'est ok s'il y a une loop et un autre segment, mais je sors un avertissement et ne corrige pas s'il y a deux loop ou encore une loop et deux autres segments. En principe ces cas derniers devraient être super rare.
3. La fonction `st_split_at_point()` causait parfois problème car elle retournait plus de deux géométries. J'ai ajusté un paramètre pour réduire le risque que ça se produise, mais ce n'est pas garanti. Il faudrait idéalement que la méthode soit revue, mais je crois que ça devrait quand même être plus robuste maintenant.