### PR TITLE
Removing `rgeos` dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,6 @@ Imports:
     fasterize,
     sp
 Suggests:
-    rgeos,
     mapview,
     leaflet,
     viridis

--- a/R/lcp_tools.R
+++ b/R/lcp_tools.R
@@ -158,8 +158,8 @@ mask_conductivity <- function(conductivity, centerline, param)
 start_end_points = function(centerline, param)
 {
   caps <- make_caps(centerline, param)$caps
-  P <- sf::st_cast(caps, "POLYGON")
-  C <- sf::st_centroid(P)
+  #P <- sf::st_cast(caps, "POLYGON")
+  C <- sf::st_centroid(caps)
   A <- sf::st_coordinates(C[1])
   B <- sf::st_coordinates(C[2])
   return(list(A = A, B = B))
@@ -245,6 +245,7 @@ transition <- function(conductivity, directions = 8, geocorrection = TRUE)
 find_path = function(trans, centerline, A, B, param)
 {
   caps <- make_caps(centerline, param)$caps
+  caps <- sf::st_union(caps)
   trans@crs <- methods::as(sf::NA_crs_, "CRS") # workaround to get rid of rgdal warning
 
   cost <- gdistance::costDistance(trans, A, B)
@@ -335,7 +336,7 @@ make_caps <- function(centerline, param)
     caps_B <- caps_B[which.max(sf::st_area(caps_B))]
 
   caps <- c(caps_A, caps_B)
-  caps <- sf::st_union(caps)
+  #caps <- sf::st_union(caps)
   shield <- sf::st_difference(sf::st_buffer(sf::st_union(caps, sf::st_union(poly1, poly2)), 0.01), shield)
 
   sf::st_crs(caps) <- sf::st_crs(centerline)

--- a/R/line_tools.R
+++ b/R/line_tools.R
@@ -61,9 +61,8 @@ st_extend_line <- function(line, distance, end = "BOTH")
 
 #' Get point from distance on a line
 #'
-#' This is essentially the reverse of rgeos::gProject(). It must be noted
-#' that due floating point precision limitation, the point returned won't be
-#' exactly on the line and thus won't split it.
+#' It must be noted that due floating point precision limitation,
+#' the point returned won't be exactly on the line and thus won't split it.
 #'
 #' @param distance  distance on the \code{line} at which the coordinates will be retrieved.
 #' @param line  line (\code{sfc} format)


### PR DESCRIPTION
Fix https://github.com/Jean-Romain/ALSroads/issues/65

Removes dependency on `rgeos` with the replacement of `rgeos::gProject()` by using only `sf` functions and objects. A second improvement will be possible at the release of `sf 1.0-16` where native equivalent functions of `rgeos::gProject()` and `rgeos::gInterpolate()` will be available as `sf::st_project_point()` and `sf::st_interpolate_line()` respectively.